### PR TITLE
Vagrant Cleanup

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from os import path
 class BaseConfiguration(object):
     HOST_NAME = 'mail.swagger.pro'
     # Make this random (used to generate session keys)
-    SECRET_KEY = 'e68bf2ea7a6494e65c9fbf2b7e652cf974281871713aa46c'
+    SECRET_KEY = '1c11d7ec3eb95e6ddb497d792452ced7ab2f3f0e41d11a20'
     basedir = path.abspath(path.dirname(__file__))
     SQLALCHEMY_DATABASE_URI = 'mysql://root:vagrant@localhost:3306/servermail'
     SQLALCHEMY_MIGRATE_REPO = path.join(basedir, 'db_repository')
@@ -22,6 +22,4 @@ class TestConfiguration(BaseConfiguration):
 
 
 class DevConfiguration(BaseConfiguration):
-    basedir = path.abspath(path.dirname(__file__))
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + path.join(basedir, 'postmaster.db')
     DEBUG = True

--- a/ops/Vagrant.sh
+++ b/ops/Vagrant.sh
@@ -70,6 +70,7 @@ echo 'Copying and enabling the standard PostMaster Apache configuration...'
 cp -f /opt/postmaster/git/ops/apache.conf /etc/apache2/sites-available/postmaster.conf
 chmod 644 /etc/apache2/sites-available/postmaster.conf
 a2ensite -q postmaster.conf > /dev/null
+echo 'export POSTMASTER_DEV=TRUE' >> /etc/apache2/envvars
 
 echo 'Restarting Apache...'
 service apache2 restart > /dev/null

--- a/postmaster/__init__.py
+++ b/postmaster/__init__.py
@@ -12,7 +12,7 @@ from flask_bcrypt import Bcrypt
 
 app = Flask(__name__)
 
-if environ.get('POSTMASTER_DEV'):
+if environ.get('POSTMASTER_DEV') == 'TRUE':
     app.config.from_object('config.DevConfiguration')
 else:
     app.config.from_object('config.BaseConfiguration')


### PR DESCRIPTION
- Removes unused preserve option from Vagrant.sh
- Removes SQLite support for dev environment
- Adds application debug in Vagrant deployment (debug output can be found in /var/log/apache2/error.log)
