### PR TITLE
Moves log file configuration to config.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Created by https://www.gitignore.io
 site.retry
+*.bak
 
 .vagrant
 .idea
@@ -66,5 +67,3 @@ target/
 
 env/
 *.deb
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 before_script:
   - ./pylint-check.py
 script:
+  - mkdir -p ../logs
   - py.test -v --cov postmaster --cov-report term-missing tests/
 after_success:
   - coveralls

--- a/config.py
+++ b/config.py
@@ -17,11 +17,13 @@ class BaseConfiguration(object):
     SQLALCHEMY_DATABASE_URI = 'mysql://root:vagrant@localhost:3306/servermail'
     basedir = path.abspath(path.dirname(__file__))
     SQLALCHEMY_MIGRATE_REPO = path.join(basedir, 'db/migrations')
+    LOG_LOCATION = '/opt/postmaster/logs/postmaster.log'
 
 
 class TestConfiguration(BaseConfiguration):
     WTF_CSRF_ENABLED = False
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    LOG_LOCATION = '../logs/postmaster.log'
     DEBUG = True
 
 

--- a/config.py
+++ b/config.py
@@ -23,7 +23,6 @@ class BaseConfiguration(object):
 class TestConfiguration(BaseConfiguration):
     WTF_CSRF_ENABLED = False
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-    LOG_LOCATION = '../logs/postmaster.log'
     DEBUG = True
 
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* 'Log File' config option is now baked into the application config and cannot be set in the api / webui / database. Use `python manage.py setlogfile <path>` or edit config.py to change the log file location. See [GH-128].
+
 Features:
 
 * Added the ability to install PostMaster via a deb package [GH-111]

--- a/docs/Configuration/CommandLineConfiguration.md
+++ b/docs/Configuration/CommandLineConfiguration.md
@@ -1,11 +1,11 @@
 ### Before You Start
 1. Logged into the server hosting PostMaster as root or as an administrator, enter the Python virtual environment (if necessary, replace the path with your install location):
-        
+
         Linux:
         source /opt/postmaster/env/bin/activate
         Windows:
         C:\PostMaster\env\Scripts\activate.ps1
-        
+
 2. Once you've entered the Python virtual environment, navigate to the location of manage.py (replace /opt/postmaster/git with your install location):
 
         cd /opt/postmaster/git
@@ -21,6 +21,8 @@ Use the following commands to restore the proper permissions on the PostMaster f
         chmod -R 550 /opt/postmaster
 
 ### Command Line Commands
+
+**setlogfile** sets the location of the logfile. The default is `/opt/postmaster/logs/postmaster.log`.
 
 **setdburi** sets the MySQL database URI that PostMaster uses to connect to the MySQL server used by your mail server.
 

--- a/docs/Configuration/ConfigurationsPage.md
+++ b/docs/Configuration/ConfigurationsPage.md
@@ -1,12 +1,8 @@
 **Minimum Password Length** specifies the minimum password length that all mail users and administrators must adhere to.
 
-**Login Auditing** determines whether login and logout events are recorded in the log file. In order to enable this, the "Log File" setting must be configured.
+**Login Auditing** determines whether login and logout events are recorded in the log file.
 
 **Mail Database Auditing** determines whether changes to domains, users, aliases, administrators, and configuration settings should be recorded in the log file.
-In order to enable this, the "Log File" setting must be configured.
-
-**Log File** specifies a file path to where the log file should be. The path can be relative or absolute, but the file location must be writable by the web server.
-When configuring this setting, "Mail Database Auditing" will be turned on automatically.
 
 **Enable LDAP Authentication** determines whether Active Directory LDAP authentication is turned on or off. In order to enable LDAP authentication,
 the "AD Server LDAP String", "AD Domain", and "AD PostMaster Group" must be configured.

--- a/docs/Installation/WindowsServer2012R2.md
+++ b/docs/Installation/WindowsServer2012R2.md
@@ -160,20 +160,24 @@ To start the migration, run the following command:
 
         python manage.py generatekey
 
-27. You may now exit the Python virtual environment:
+27. By deafult, PostMaster logs to a Linux based path, run the following command to change the log to the text file created in step 11:
+
+        python manage.py setlogfile "$env:SystemDrive\PostMaster\logs\postmaster.log"
+
+28. You may now exit the Python virtual environment:
 
         deactivate
 
-28. Restart IIS to make sure all the changes take effect:
+29. Restart IIS to make sure all the changes take effect:
 
         iisreset
 
-29. At this point it is highly recommended that you implement SSL before using PostMaster in production.
+30. At this point it is highly recommended that you implement SSL before using PostMaster in production.
 
-29. PostMaster should now be running. Simply use the username "admin" and the password "PostMaster" to login.
+31. PostMaster should now be running. Simply use the username "admin" and the password "PostMaster" to login.
 You can change your username and password from Manage -> Administrators.
 
-30. Please keep in mind that the C:\PostMaster\git\db\migrations folder should be backed up after installation/updates.
+32. Please keep in mind that the C:\PostMaster\git\db\migrations folder should be backed up after installation/updates.
 This is because PostMaster uses database migrations to safely upgrade the database schema,
 and this folder contains auto-generated database migration scripts that allow you to revert back if a database migration ever failed.
 If this folder is missing, PostMaster can't tell what state your database is in, and therefore, cannot revert back.

--- a/manage.py
+++ b/manage.py
@@ -77,5 +77,17 @@ def setdburi(uri):
         else:
             print(line.rstrip())
 
+
+@manager.command
+def setlogfile(filepath):
+    """Replaces the BaseConfiguration LOG_LOCATION in config.py with one supplied"""
+    base_config_set = False
+    for line in fileinput.input('config.py', inplace=True, backup='.bak'):
+        if not base_config_set and 'LOG_LOCATION' in line:
+            print(sub(r'(?<=LOG_LOCATION = \')(.+)(?=\')', filepath, line.rstrip()))
+            base_config_set = True
+        else:
+            print(line.rstrip())
+
 if __name__ == "__main__":
     manager.run()

--- a/postmaster/apiv1/utils.py
+++ b/postmaster/apiv1/utils.py
@@ -26,10 +26,16 @@ def is_file_writeable(file):
 
 def is_config_update_valid(setting, value, valid_value_regex):
     """ A helper function for the update_config function on the /configs/<int:config_id> PUT route.
-    A bool is returned based on if the users input is valid.
+    A bool is returned based on if the user's input is valid.
     """
     if match(valid_value_regex, value):
-        if setting == 'Enable LDAP Authentication':
+        if setting == 'Login Auditing' or setting == 'Mail Database Auditing':
+            log_path = app.config.get('LOG_LOCATION')
+            if not log_path or not is_file_writeable(log_path):
+                raise ValidationError('The log could not be written to "{0}". '
+                                      'Verify that the path exists and is writeable.'.format(os.path.abspath(log_path)))
+
+        elif setting == 'Enable LDAP Authentication':
             ldap_string = Configs.query.filter_by(setting='AD Server LDAP String').first().value
             ad_domain = Configs.query.filter_by(setting='AD Domain').first().value
             ad_group = Configs.query.filter_by(setting='AD PostMaster Group').first().value

--- a/postmaster/static/js/configs.js
+++ b/postmaster/static/js/configs.js
@@ -2,7 +2,6 @@
 function configEventListeners () {
     var configBoolItems = $('a.configBool');
     var configTextItems = $('a.configText');
-    var configLogFile = $('a.configLogFile');
 
     configBoolItems.unbind();
     configBoolItems.tooltip();
@@ -18,19 +17,6 @@ function configEventListeners () {
     configTextItems.unbind();
     configTextItems.tooltip();
     configTextItems.editable({
-        display: function (value) {
-            $(this).html(filterText(value));
-        }
-    });
-
-    configLogFile.unbind();
-    configLogFile.tooltip();
-    configLogFile.editable({
-        success: function () {
-            // Sets the Mail Database Auditing to True in the UI
-            $('td:contains("Mail Database Auditing")').next('td').children('a').text('True');
-            addStatusMessage('success', 'The setting was changed successfully');
-        },
         display: function (value) {
             $(this).html(filterText(value));
         }
@@ -61,10 +47,7 @@ function fillInTable () {
                 'Enable LDAP Authentication'
             ];
 
-            if (item.setting == 'Log File') {
-                var cssClass = 'configLogFile'
-            }
-            else if($.inArray(item.setting, boolConfigItems) != -1) {
+            if($.inArray(item.setting, boolConfigItems) != -1) {
                 var cssClass = 'configBool'
             }
             else {

--- a/postmaster/utils.py
+++ b/postmaster/utils.py
@@ -11,7 +11,7 @@ from json import dumps
 from datetime import datetime
 from os import getcwd
 from wtforms.validators import StopValidation as WtfStopValidation
-from postmaster import db, models, bcrypt
+from postmaster import app, db, models, bcrypt
 from postmaster.errors import ValidationError
 
 
@@ -36,7 +36,7 @@ def json_logger(category, admin, message):
     Takes a category (typically error or audit), a log message and the responsible
     user. It then appends it with an ISO 8601 UTC timestamp to a JSON formatted log file
     """
-    log_path = models.Configs.query.filter_by(setting='Log File').first().value
+    log_path = app.config.get('LOG_LOCATION')
     if log_path and ((category == 'error') or
        (category == 'audit' and maildb_auditing_enabled()) or
        (category == 'auth' and login_auditing_enabled())):
@@ -82,12 +82,6 @@ def add_default_configuration_settings():
         mail_db_auditing.value = 'False'
         mail_db_auditing.regex = '^(True|False)$'
         db.session.add(mail_db_auditing)
-
-    if not models.Configs.query.filter_by(setting='Log File').first():
-        log_file = models.Configs()
-        log_file.setting = 'Log File'
-        log_file.regex = '^(.+)$'
-        db.session.add(log_file)
 
     if not models.Configs.query.filter_by(setting='Enable LDAP Authentication').first():
         ldap_auth = models.Configs()

--- a/postmaster/utils.py
+++ b/postmaster/utils.py
@@ -9,7 +9,7 @@ from struct import unpack
 from re import search, sub, IGNORECASE
 from json import dumps
 from datetime import datetime
-from os import getcwd
+from os import path
 from wtforms.validators import StopValidation as WtfStopValidation
 from postmaster import app, db, models, bcrypt
 from postmaster.errors import ValidationError
@@ -32,8 +32,7 @@ def login_auditing_enabled():
 
 
 def json_logger(category, admin, message):
-    """
-    Takes a category (typically error or audit), a log message and the responsible
+    """ Takes a category (typically error or audit), a log message and the responsible
     user. It then appends it with an ISO 8601 UTC timestamp to a JSON formatted log file
     """
     log_path = app.config.get('LOG_LOCATION')
@@ -52,10 +51,8 @@ def json_logger(category, admin, message):
                     sort_keys=True)))
                 log_file.close()
         except IOError:
-            raise ValidationError(
-                'The log could not be written to  "{0}". \
-                Verify that the path exists and is writeable.'.format(
-                    getcwd().replace('\\', '/') + '/' + log_path))
+            raise ValidationError('The log could not be written to "{0}". '
+                                  'Verify that the path exists and is writeable.'.format(path.abspath(log_path)))
 
 
 def add_default_configuration_settings():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ def initialize():
         db.drop_all()
         db.create_all()
         add_default_configuration_settings()
-        config_maildb_auditing = models.Configs.query.filter_by(setting='Mail Database Auditing').first()
-        config_maildb_auditing.value = 'True'
+        admin2 = models.Admins().from_json(
+            {'username': 'admin2', 'password': 'PostMaster2', 'name': 'Some Admin'})
         enable_ldap_auth = models.Configs.query.filter_by(setting='Enable LDAP Authentication').first()
         enable_ldap_auth.value = 'True'
         ldap_server = models.Configs.query.filter_by(setting='AD Server LDAP String').first()
@@ -22,7 +22,7 @@ def initialize():
         ldap_admin_group.value = 'PostMaster Admins'
 
         try:
-            db.session.add(config_maildb_auditing)
+            db.session.add(admin2)
             db.session.add(enable_ldap_auth)
             db.session.add(ldap_server)
             db.session.add(domain)
@@ -73,8 +73,14 @@ def initialize():
 
     return False
 
-# Create a fresh database
-initialize()
+
+# Reinitialize the database before each test
+@pytest.yield_fixture(autouse=True)
+def run_before_tests():
+    # Code that runs before each test
+    initialize()
+    # A test function will be run at this point
+    yield
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ def initialize():
         add_default_configuration_settings()
         config_maildb_auditing = models.Configs.query.filter_by(setting='Mail Database Auditing').first()
         config_maildb_auditing.value = 'True'
-        config_log_path = models.Configs.query.filter_by(setting='Log File').first()
-        config_log_path.value = 'postmaster.log'
         enable_ldap_auth = models.Configs.query.filter_by(setting='Enable LDAP Authentication').first()
         enable_ldap_auth.value = 'True'
         ldap_server = models.Configs.query.filter_by(setting='AD Server LDAP String').first()
@@ -25,7 +23,6 @@ def initialize():
 
         try:
             db.session.add(config_maildb_auditing)
-            db.session.add(config_log_path)
             db.session.add(enable_ldap_auth)
             db.session.add(ldap_server)
             db.session.add(domain)


### PR DESCRIPTION
Moving the log file configuration to the config.py is a safer choice than allowing it to be configured in the web interface and api. 

In order to change the log file location: 
 - `python manage.py setlogfile <path>` or edit config.py
 - Restart the application `(service apache2 restart)`


I dislike importing `app` to get the config value in the utils files. I was using `current_app`, but this broke the tests because it was working out of the context of the application. 

Fixes #107 