### PR TITLE
Use PyMySQL over MySQL-Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get install -y \
     libyaml-dev \
     libpython2.7-dev \
     sqlite3 \
-    libmysqlclient-dev && \
     apt-get autoremove -y && \
     apt-get clean
 RUN /usr/sbin/apache2ctl stop && systemctl disable apache2

--- a/config.default.py
+++ b/config.default.py
@@ -14,7 +14,7 @@ class BaseConfiguration(object):
     # Make this random (used to generate session keys)
     SECRET_KEY = '123456789abcdef123456789'
     SQLALCHEMY_TRACK_MODIFICATIONS = True
-    SQLALCHEMY_DATABASE_URI = 'mysql://root:vagrant@localhost:3306/servermail'
+    SQLALCHEMY_DATABASE_URI = 'pymysql://root:vagrant@localhost:3306/servermail'
     basedir = path.abspath(path.dirname(__file__))
     LOG_LOCATION = '/opt/postmaster/logs/postmaster.log'
 

--- a/docs/Installation/Docker.md
+++ b/docs/Installation/Docker.md
@@ -54,7 +54,7 @@ Make sure to replace 'password_changeme' and 'docker.postmaster.local' with what
 
         docker run \
              -p 0.0.0.0:80:8082 \
-             -e DB_URI=mysql://postmasteruser:password_changeme@docker.postmaster.local:3306/servermail \
+             -e DB_URI=pymysql://postmasteruser:password_changeme@docker.postmaster.local:3306/servermail \
              -v /opt/postmaster_data/logs:/opt/postmaster/logs \
              -d postmaster
 

--- a/docs/Installation/Ubuntu1404.md
+++ b/docs/Installation/Ubuntu1404.md
@@ -75,7 +75,7 @@ You can change your username and password from Manage -> Administrators.
 
 3. Install the required packages for PostMaster:
 
-        apt-get install python python-pip python-dev libldap2-dev libssl-dev libsasl2-dev libffi-dev apache2 libapache2-mod-wsgi mysql-server libmysqlclient-dev
+        apt-get install python python-pip python-dev libldap2-dev libssl-dev libsasl2-dev libffi-dev apache2 libapache2-mod-wsgi mysql-server
 
 4. Make sure you are running Python 2.7 as your default Python installation, as PostMaster relies on Python 2.7:
 

--- a/docs/Installation/Ubuntu1404.md
+++ b/docs/Installation/Ubuntu1404.md
@@ -45,7 +45,7 @@ Make sure to replace "password_changeme" with the actual password supplied in st
 replace '127.0.0.1' with the IP address or DNS specified in step 2 of MySQL Preparation:
 
         cd /opt/postmaster/git
-        python manage.py setdburi 'mysql://postmasteruser:password_changeme@127.0.0.1:3306/servermail'
+        python manage.py setdburi 'pymysql://postmasteruser:password_changeme@127.0.0.1:3306/servermail'
 
 5. PostMaster needs to create a few tables under the servermail database. This is done via a database migration,
 which means that only the necessary changes to the database are made, and these changes are reversible if something went wrong.

--- a/ops/ansible/roles/postmaster_deploy/tasks/main.yml
+++ b/ops/ansible/roles/postmaster_deploy/tasks/main.yml
@@ -18,7 +18,6 @@
     - libffi-dev
     - apache2
     - libapache2-mod-wsgi
-    - libmysqlclient-dev
   when: provision_type == "dev"
 
 - name: Create virtualenv directory

--- a/ops/ansible/roles/postmaster_deploy/tasks/mysql.yml
+++ b/ops/ansible/roles/postmaster_deploy/tasks/mysql.yml
@@ -13,10 +13,6 @@
   become: yes
   apt: pkg=mysql-server state=latest
 
-- name: Install mysql-python globally for this next command :(
-  pip: name=MySQL-python
-  become: yes
-
 - name: Create default database for mysql
   mysql_db: name=servermail state=present login_user=root login_password=vagrant
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ Flask-SQLAlchemy
 Flask-WTF
 mock
 mockldap
-mysqlclient
+pymysql
 passlib
 pylint
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,12 +31,12 @@ MarkupSafe==0.23          # via jinja2, mako
 mccabe==0.5.2             # via pylint
 mock==2.0.0
 mockldap==0.2.8
-mysqlclient==1.3.7
 passlib==1.6.5
 pbr==1.10.0               # via mock
 py==1.4.31                # via pytest
 pycparser==2.14           # via cffi
 pylint==1.6.4
+PyMySQL==0.7.6
 pytest-cov==2.3.1
 pytest==2.9.2
 python-editor==1.0.1      # via alembic


### PR DESCRIPTION
PyMySQL is a pure-python module that can be a  drop-in replacement for MySQL-Python to allow for an easier deployment process.