### PR TITLE
Vagrant tweaks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(2) do |config|
         override.vm.box = "elastic/ubuntu-16.04-x86_64"
         override.vm.synced_folder "./", "/opt/postmaster/git", type: "sshfs", sshfs_opts_append: "-o nonempty"
     end
-    config.vm.network "forwarded_port", guest: 8082, host: 8080
+    config.vm.network "forwarded_port", guest: 5000, host: 8080
     config.vm.synced_folder "./", "/opt/postmaster/git"
     config.vm.provision "shell", inline: "apt-get update && apt-get install -y git"
     config.vm.provision "ansible_local" do |ansible|
@@ -33,6 +33,9 @@ Vagrant.configure(2) do |config|
             }]
         }
     end
-    # We have to change the permission of config.py to world readable since ownership can't be modified on a synced folder
+    # We have to change the permission of config.py to world readable since
+    # ownership can't be modified on a synced folder
     config.vm.provision "shell", inline: "chmod 664 /opt/postmaster/git/config.py"
+    # Start the dev server
+    config.vm.provision "shell", inline: "/opt/postmaster/env/bin/python /opt/postmaster/git/manage.py runserver --host 0.0.0.0 &", run: "always"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure(2) do |config|
     config.vm.box = "boxcutter/ubuntu1604"
     config.vm.provider "libvirt" do |v, override|
         override.vm.box = "elastic/ubuntu-16.04-x86_64"
+        override.vm.synced_folder "./", "/opt/postmaster/git", type: "sshfs", sshfs_opts_append: "-o nonempty"
     end
     config.vm.network "forwarded_port", guest: 8082, host: 8080
     config.vm.synced_folder "./", "/opt/postmaster/git"

--- a/docs/Development/DevEnvironment.md
+++ b/docs/Development/DevEnvironment.md
@@ -9,16 +9,13 @@ not required on the host system.
 - Install Vagrant by using your package manager or downloading it at:
 [https://www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)
 
+- If you are using libvirt as your Vagrant provider (typical use case when
+developing on Fedora), you must have the `sshfs` Vagrant plugin installed. To
+install it, either run `sudo dnf install vagrant-sshfs` or
+`vagrant install sshfs`.
+
 - Run `vagrant up` to provision a Vagrant guest (development VM). Some operating
 systems require running vagrant with `sudo` or administrative rights.
-
-- If you are using libvirt as your Vagrant provider (typical use case when 
-developing on Fedora), you must run `cp config.default.py config.py` in the
-PostMaster git directory. This is because the folder syncing is done through
-rsync, which is not bidirectional and therefore, the next time the folder syncs,
-the `config.py` file created by Vagrant (using Ansible) on the guest VM will be
-lost. To turn on automatic folder syncing if you are using libvirt, always run
-`vagrant rsync-auto` after running `vagrant up`.
 
 - Access PostMaster at [http://localhost:8080](http://localhost:8080) via your web browser
 


### PR DESCRIPTION
Relies on https://github.com/StackFocus/ansible-role-postmaster/pull/10.

This enables SSHFS when using libvirt with Vagrant and uses the development server instead of Apache.